### PR TITLE
Add handler for munin service

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,3 @@
 ---
-# TODO
+- name: restart munin
+  service: name=munin-node state=restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,7 @@
   with_items:
     - { src: munin.conf.j2, dest: /etc/munin/munin.conf }
     - { src: hosts.conf.j2, dest: "{{ munin_conf_d_directory }}/hosts.conf" }
+  notify: restart munin
 
 - name: Create munin user via htpasswd.
   htpasswd: >


### PR DESCRIPTION
The service name for munin master and node is the same. Also added a notifier in tasks so now whenever a change is made to either conf files munin gets restarted.

I don't know if this is reduntant given the fact that the scripts that run with cron every 5 min take care of loading the confs. But again someone might disable cron.

btw thanks for this role :beers: 