### PR TITLE
avoid obligation to declare "extra" in munin_hosts

### DIFF
--- a/templates/hosts.conf.j2
+++ b/templates/hosts.conf.j2
@@ -2,7 +2,7 @@
 {% for host in munin_hosts %}
 [{{ host.name }}]
     address {{ host.address }}
-{% if host.extra %}
+{% if host.extra is defined %}
 {% for extra in host.extra %}
     {{ extra }}
 {% endfor %}


### PR DESCRIPTION
avoid obligation to declare "extra" param in munin_hosts list
allow this simple syntax : 

```yaml
munin_hosts:
  - {
    name: "localhost",
    address: "127.0.0.1"
  }
```