### PR TITLE
Fix deprecation warnings when using yum/apt with loops

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,13 +3,11 @@
   include_vars: "{{ ansible_os_family }}.yml"
 
 - name: Install required packages for munin (RedHat).
-  yum: "name={{ item }} state=present"
-  with_items: "{{ munin_packages }}"
+  yum: "name={{ munin_packages }} state=present"
   when: ansible_os_family == 'RedHat'
 
 - name: Install required packages for munin (Debian).
-  apt: "name={{ item }} state=present"
-  with_items: "{{ munin_packages }}"
+  apt: "name={{ munin_packages }} state=present"
   when: ansible_os_family == 'Debian'
 
 - name: Copy munin configurations.


### PR DESCRIPTION
warning - `[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ item }}"`, please
use `name: '{{ munin_packages }}'` and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.`