### PR TITLE
Use the same shell construct than upstream.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,4 +36,4 @@
     dest: /etc/cron.d/munin
     state: "{{ munin_cron_job }}"
     regexp: "^\\*/5 \\* \\* \\* \\*"
-    line: "*/5 * * * *     munin test -x /usr/bin/munin-cron && /usr/bin/munin-cron"
+    line: "*/5 * * * *     munin if [ -x /usr/bin/munin-cron ]; then /usr/bin/munin-cron; fi"


### PR DESCRIPTION
This avoid package managers to think the file was modified and want to
replace it at upgrade time.

[Debian package](https://salsa.debian.org/debian/munin/-/blob/debian/debian/munin.cron.d) and [upstream Munin documentation](https://github.com/munin-monitoring/munin/blob/master/doc/example/service/cron/crontab-generic-munin) both use this `if` construction.