### PR TITLE
Ensure cron file exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,3 +37,4 @@
     state: "{{ munin_cron_job }}"
     regexp: "^\\*/5 \\* \\* \\* \\*"
     line: "*/5 * * * *     munin if [ -x /usr/bin/munin-cron ]; then /usr/bin/munin-cron; fi"
+    create: yes


### PR DESCRIPTION
On our Amazon linux 2 servers it throws an error when writing the /etc/cron.d/munin file if it doesn't exist.
Just added a the "create: yes" parameter so that it creates the file if it doesn't exist.