### PR TITLE
Make `address` key in `munin_hosts` optional

### DIFF
--- a/templates/hosts.conf.j2
+++ b/templates/hosts.conf.j2
@@ -1,7 +1,9 @@
 # Munin hosts.
 {% for host in munin_hosts %}
 [{{ host.name }}]
+{% if host.address is defined %}
     address {{ host.address }}
+{% endif %}
 {% if host.extra is defined %}
 {% for extra in host.extra %}
     {{ extra }}


### PR DESCRIPTION
The `address` key of hosts in the `munin_hosts` variable is required by `ansible-role-munin` but not mandatory in real-life.

In fact you can configure munin to render very relevant infos by setting group orders, computed values and much more with "virtual hosts" that do not have any address. 

Example (note the two latter sections w/o an `address` parameter):
```
# Munin hosts
[h1.sample.com]
    address 1.2.3.4
[h2.sample.com]
    address 4.3.2.1
[sample.com;totals]
    update no
    load1.graph_title Loads (side by side)
    load1.graph_order h1=h1.sample.com:load.load h2=h2.sample.com:load.load
[sample.com;]
    node_order totals h1.sample.com h2.sample.com
```
This can be very handy and is a valid munin configuration.

I therefore propose this tiny change to make the `address` attribute of hosts in `munin_hosts` optional, when parsing the `hosts.conf.j2 template`.